### PR TITLE
ci: Allow fails for clang build since packaging is currently broken.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,26 @@
 language: c
-addons:
-  apt:
-    sources:
-      - ubuntu-toolchain-r-test
-      - llvm-toolchain-trusty-5.0
-    packages:
-      - g++-7
-      - clang-5.0
 
 matrix:
   include:
     - compiler: gcc
       env: CXX=g++-7
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-7
 
     - compiler: clang
       env: CXX=clang++-5.0
+      addons:
+        apt:
+          sources:
+            - llvm-toolchain-trusty-5.0
+          packages:
+            - clang-5.0
+  allow_failures:
+    - compiler: clang
 
 before_install:
   - sudo apt-get update -qq


### PR DESCRIPTION
Signed-off-by: Alfredo Beaumont <alfredo.beaumont@gmail.com>