### PR TITLE
A pair of fixes

### DIFF
--- a/src/uast.c
+++ b/src/uast.c
@@ -38,7 +38,7 @@ void Error(void *ctx, const char *msg, ...);
 ///////// PUBLIC API /////////
 //////////////////////////////
 
-Nodes *NodesNew() { return calloc(1, sizeof(Nodes)); }
+Nodes *NodesNew(void) { return calloc(1, sizeof(Nodes)); }
 
 void NodesFree(Nodes *nodes) {
   if (nodes) {
@@ -137,7 +137,7 @@ error1:
   return nodes;
 }
 
-char *LastError() {
+char *LastError(void) {
   return strndup(error_message, BUF_SIZE);
 }
 

--- a/src/uast.c
+++ b/src/uast.c
@@ -57,7 +57,7 @@ void *NodeAt(const Nodes *nodes, int index) {
 }
 
 Uast *UastNew(NodeIface iface) {
-  memset(error_message, BUF_SIZE, 0);
+  memset(error_message, 0, BUF_SIZE);
   Uast *ctx = calloc(1, sizeof(Uast));
   if (!ctx) {
     Error(NULL, "Unable to get memory\n");

--- a/src/uast.h
+++ b/src/uast.h
@@ -52,7 +52,7 @@ Nodes *UastFilter(const Uast *ctx, void *node, const char *query);
 // It may be an empty string if there's been no error.
 //
 // Memory for the string is obtained with malloc, and can be freed with free.
-char *LastError();
+char *LastError(void);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/src/uast_private.h
+++ b/src/uast_private.h
@@ -12,7 +12,7 @@ extern "C" {
 // These functions are used internally for testing and not exported.
 
 // Returns a new Nodes structure
-Nodes *NodesNew();
+Nodes *NodesNew(void);
 
 // Sets the size of nodes, allocating space if needed.
 // Returns 0 if the size was changed correctly.


### PR DESCRIPTION
* Make `void` explicit for empty parameters (for backwards compatibility in C)
* Fix the order of arguments in `memset`.