### PR TITLE
Make the example binary depend on the shared library build.

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -7,4 +7,4 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17" CACHE STRING "" FORCE)
 
 add_executable(example example.cc)
 target_link_libraries(example uast)
-
+target_link_libraries(example ${libshared})


### PR DESCRIPTION
Fixes #19

Signed-off-by: Juanjo Alvarez <juanjo@sourced.tech>