### PR TITLE
Remove usage of optional to let tests/example build with just C++11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,26 +1,7 @@
 language: c
-
-matrix:
-  include:
-    - compiler: gcc
-      env: CXX=g++-7
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - g++-7
-
-    - compiler: clang
-      env: CXX=clang++-5.0
-      addons:
-        apt:
-          sources:
-            - llvm-toolchain-trusty-5.0
-          packages:
-            - clang-5.0
-  allow_failures:
-    - compiler: clang
+compiler:
+  - clang
+  - gcc
 
 before_install:
   - sudo apt-get update -qq

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,9 +1,6 @@
 project (LIBUAST_EXAMPLES C CXX)
 
-# Since older versions of CMake don't support C++ 17 standard yet,
-# hardcode flags instead of using
-# set (CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17" CACHE STRING "" FORCE)
+set (CMAKE_CXX_STANDARD 11)
 
 add_executable(example example.cc)
 target_link_libraries(example uast)

--- a/examples/example.cc
+++ b/examples/example.cc
@@ -1,7 +1,6 @@
 #include <cstdint>
 
 #include <iostream>
-#include <optional>
 #include <string>
 #include <tuple>
 #include <vector>
@@ -12,7 +11,13 @@ struct position {
   uint32_t offset;
   uint32_t line;
   uint32_t col;
+
+  bool operator!=(const position& other) {
+    return offset != other.offset || line != other.line || col != other.col;
+  }
 };
+
+const position NO_POSITION = {0, 0, 0};
 
 class Node {
  public:
@@ -23,10 +28,10 @@ class Node {
   std::vector<uint16_t> roles;
   std::vector<std::tuple<std::string, std::string>> properties;
 
-  std::optional<position> start_position;
-  std::optional<position> end_position;
+  position start_position;
+  position end_position;
 
-  Node(std::string i) : internal_type(i) {}
+  Node(std::string i) : internal_type(i), start_position(NO_POSITION), end_position(NO_POSITION) {}
 
   void AddChild(Node *node) { children.push_back(node); }
 
@@ -45,8 +50,7 @@ static const char *Token(const void *node) {
 }
 
 static int ChildrenSize(const void *node) {
-  return ((Node *)node)->children.size();
-}
+  return ((Node *)node)->children.size();}
 
 static void *ChildAt(const void *node, int index) {
   return ((Node *)node)->children.at(index);
@@ -71,57 +75,51 @@ static const char *PropertyValueAt(const void *node, int index) {
 }
 
 static bool HasStartOffset(const void *node) {
-  return ((Node *)node)->start_position.has_value();
+  return ((Node *)node)->start_position != NO_POSITION;
 }
 
 static uint32_t StartOffset(const void *node) {
-  std::optional<position> p = ((Node *)node)->start_position;
-  return p.has_value() ? p.value().offset : 0;
+  return ((Node *)node)->start_position.offset;
 }
 
 static bool HasStartLine(const void *node) {
-  return ((Node *)node)->start_position.has_value();
+  return ((Node *)node)->start_position != NO_POSITION;
 }
 
 static uint32_t StartLine(const void *node) {
-  std::optional<position> p = ((Node *)node)->start_position;
-  return p.has_value() ? p.value().line : 0;
+  return ((Node *)node)->start_position.line;
 }
 
 static bool HasStartCol(const void *node) {
-  return ((Node *)node)->start_position.has_value();
+  return ((Node *)node)->start_position != NO_POSITION;
 }
 
 static uint32_t StartCol(const void *node) {
-  std::optional<position> p = ((Node *)node)->start_position;
-  return p.has_value() ? p.value().col : 0;
+  return ((Node *)node)->start_position.col;
 }
 
 static bool HasEndOffset(const void *node) {
-  return ((Node *)node)->end_position.has_value();
+  return ((Node *)node)->end_position != NO_POSITION;
 }
 
 static uint32_t EndOffset(const void *node) {
-  std::optional<position> p = ((Node *)node)->end_position;
-  return p.has_value() ? p.value().offset : 0;
+  return ((Node *)node)->end_position.offset;
 }
 
 static bool HasEndLine(const void *node) {
-  return ((Node *)node)->end_position.has_value();
+  return ((Node *)node)->end_position != NO_POSITION;
 }
 
 static uint32_t EndLine(const void *node) {
-  std::optional<position> p = ((Node *)node)->end_position;
-  return p.has_value() ? p.value().line : 0;
+  return ((Node *)node)->end_position.line;
 }
 
 static bool HasEndCol(const void *node) {
-  return ((Node *)node)->end_position.has_value();
+  return ((Node *)node)->end_position != NO_POSITION;
 }
 
 static uint32_t EndCol(const void *node) {
-  std::optional<position> p = ((Node *)node)->end_position;
-  return p.has_value() ? p.value().col : 0;
+  return ((Node *)node)->end_position.col;
 }
 
 int main(int argc, char **argv) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,9 +1,6 @@
 project (LIBUAST_TESTS C CXX)
 
-# Since older versions of CMake don't support C++ 17 standard yet,
-# hardcode flags instead of using
-# set (CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17" CACHE STRING "" FORCE)
+set (CMAKE_CXX_STANDARD 11)
 
 enable_testing()
 

--- a/tests/mock_node.h
+++ b/tests/mock_node.h
@@ -4,7 +4,6 @@
 #include <cstdint>
 
 #include <iostream>
-#include <optional>
 #include <string>
 #include <tuple>
 #include <vector>
@@ -15,7 +14,13 @@ struct position {
   uint32_t offset;
   uint32_t line;
   uint32_t col;
+
+  bool operator!=(const position& other) {
+    return offset != other.offset || line != other.line || col != other.col;
+  }
 };
+
+const position NO_POSITION = {0, 0, 0};
 
 class Node {
  public:
@@ -26,10 +31,10 @@ class Node {
   std::vector<uint16_t> roles;
   std::vector<std::tuple<std::string, std::string>> properties;
 
-  std::optional<position> start_position;
-  std::optional<position> end_position;
+  position start_position;
+  position end_position;
 
-  Node(std::string i) : internal_type(i) {}
+  Node(std::string i) : internal_type(i), start_position(NO_POSITION), end_position(NO_POSITION) {}
 
   void AddChild(Node *node) { children.push_back(node); }
 
@@ -78,57 +83,51 @@ static const char *PropertyValueAt(const void *node, int index) {
 }
 
 static bool HasStartOffset(const void *node) {
-  return ((Node *)node)->start_position.has_value();
+  return ((Node *)node)->start_position != NO_POSITION;
 }
 
 static uint32_t StartOffset(const void *node) {
-  std::optional<position> p = ((Node *)node)->start_position;
-  return p.has_value() ? p.value().offset : 0;
+  return ((Node *)node)->start_position.offset;
 }
 
 static bool HasStartLine(const void *node) {
-  return ((Node *)node)->start_position.has_value();
+  return ((Node *)node)->start_position != NO_POSITION;
 }
 
 static uint32_t StartLine(const void *node) {
-  std::optional<position> p = ((Node *)node)->start_position;
-  return p.has_value() ? p.value().line : 0;
+  return ((Node *)node)->start_position.line;
 }
 
 static bool HasStartCol(const void *node) {
-  return ((Node *)node)->start_position.has_value();
+  return ((Node *)node)->start_position != NO_POSITION;
 }
 
 static uint32_t StartCol(const void *node) {
-  std::optional<position> p = ((Node *)node)->start_position;
-  return p.has_value() ? p.value().col : 0;
+  return ((Node *)node)->start_position.col;
 }
 
 static bool HasEndOffset(const void *node) {
-  return ((Node *)node)->end_position.has_value();
+  return ((Node *)node)->end_position != NO_POSITION;
 }
 
 static uint32_t EndOffset(const void *node) {
-  std::optional<position> p = ((Node *)node)->end_position;
-  return p.has_value() ? p.value().offset : 0;
+  return ((Node *)node)->end_position.offset;
 }
 
 static bool HasEndLine(const void *node) {
-  return ((Node *)node)->end_position.has_value();
+  return ((Node *)node)->end_position != NO_POSITION;
 }
 
 static uint32_t EndLine(const void *node) {
-  std::optional<position> p = ((Node *)node)->end_position;
-  return p.has_value() ? p.value().line : 0;
+  return ((Node *)node)->end_position.line;
 }
 
 static bool HasEndCol(const void *node) {
-  return ((Node *)node)->end_position.has_value();
+  return ((Node *)node)->end_position != NO_POSITION;
 }
 
 static uint32_t EndCol(const void *node) {
-  std::optional<position> p = ((Node *)node)->end_position;
-  return p.has_value() ? p.value().col : 0;
+  return ((Node *)node)->end_position.col;
 }
 
 static NodeIface IfaceMock() {


### PR DESCRIPTION
Fixes #51, supersedes #52 with a simpler approach: drop usage of optionals entirely instead of just wrap them, resulting in simpler code and lower requirements.