### PR TITLE
Skip null results from xmlXPathEvalExpression 

### DIFF
--- a/src/uast.cc
+++ b/src/uast.cc
@@ -143,6 +143,8 @@ Nodes *UastFilter(const Uast *ctx, void *node, const char *query) {
   xmlXPathObjectPtr xpathObj = nullptr;
   bool ok = false;
   int size = 0;
+  int realSize = 0;
+  int nodeIdx = 0;
   xmlNodeSetPtr result = nullptr;
   xmlNodePtr *results = nullptr;
   xmlGenericErrorFunc handler;
@@ -180,14 +182,24 @@ Nodes *UastFilter(const Uast *ctx, void *node, const char *query) {
   results = result->nodeTab;
   size = (result) ? result->nodeNr : 0;
 
-  if (NodesSetSize(nodes, size) != 0) {
+  // Sometimes libxml return null results for some invalid queries; do
+  // a first pass to discard them and get the real size for the result
+  for (int i = 0; i < size; i++) {
+    if (results[i] != nullptr && results[i]->_private != nullptr) {
+      ++realSize;
+    }
+  }
+
+  if (NodesSetSize(nodes, realSize) != 0) {
     Error(nullptr, "Unable to set nodes size\n");
     goto error3;
   }
 
   // Populate array of results
   for (int i = 0; i < size; i++) {
-    nodes->results[i] = results[i]->_private;
+    if (results[i] != nullptr && results[i]->_private != nullptr) {
+      nodes->results[nodeIdx++] = results[i]->_private;
+    }
   }
   ok = true;
 

--- a/tests/main.cc
+++ b/tests/main.cc
@@ -42,6 +42,7 @@ int main() {
   ADD_TEST(suite, "test of UastFilter() with end line", TestUastFilterEndLine);
   ADD_TEST(suite, "test of UastFilter() with end col", TestUastFilterEndCol);
   ADD_TEST(suite, "test of UastFilter() with position", TestUastFilterPosition);
+  ADD_TEST(suite, "test of UastFilter() with bad query", TestUastFilterBadQuery);
   ADD_TEST(suite, "test failing UastFilter() (bad Xpath)", TestXpath);
   ADD_TEST(suite, "test failing UastFilter() (bad xmlNewDoc)", TestXmlNewDoc);
   ADD_TEST(suite, "test failing UastFilter() (bad xmlNewNode)", TestXmlNewNode);

--- a/tests/nodes_test.h
+++ b/tests/nodes_test.h
@@ -236,6 +236,14 @@ void TestUastFilterPosition() {
   CU_ASSERT_FATAL(NodesSize(nodes) == 7);
 }
 
+void TestUastFilterBadQuery() {
+  Uast *ctx = UastNew(IfaceMock());
+  Node *root = TreeMock();
+  Nodes *nodes = UastFilter(ctx, root, "//@roleModule");
+  CU_ASSERT_FATAL(nodes != NULL);
+  CU_ASSERT_FATAL(NodesSize(nodes) == 0);
+}
+
 void TestUastIteratorPreOrder() {
   Uast *ctx = UastNew(IfaceMock());
   Node *root = TreeMock();


### PR DESCRIPTION
Fixes bblfsh/client-python/issues/60.

Context: 

Usually `libxml2` returns an error with the query in the issue but in this specific case (parsing with the file in the issue) it just return null results. This PR skips them.

I'll try to create a minimal test case to reproduce the problem and open an issue with them, but it's not trivial.