### PR TITLE
Node transform callback for Iterators.

### DIFF
--- a/src/uast.cc
+++ b/src/uast.cc
@@ -536,8 +536,6 @@ static xmlDocPtr CreateDocument(const Uast *ctx, void *node) {
 }
 
 void Error(void *ctx, const char *msg, ...) {
-  assert(ctx);
-
   va_list arg_ptr;
 
   va_start(arg_ptr, msg);

--- a/src/uast.cc
+++ b/src/uast.cc
@@ -3,6 +3,7 @@
 #include "uast.h"
 #include "uast_private.h"
 
+#include <cassert>
 #include <cinttypes>
 #include <cstdbool>
 #include <cstring>
@@ -76,6 +77,10 @@ class QueryResult {
   QueryResult(const Uast *ctx, void *node, const char *query,
               xmlXPathObjectType expected) {
 
+    assert(ctx);
+    assert(node);
+    assert(query);
+
     auto handler = (xmlGenericErrorFunc)Error;
     initGenericErrorDefaultFunc(&handler);
 
@@ -126,6 +131,8 @@ class CreateXMLNodeException: public std::runtime_error {
 };
 
 static UastIterator *UastIteratorNewBase(const Uast *ctx, void *node, TreeOrder order) {
+  assert(ctx);
+  assert(node);
 
   UastIterator *iter;
 
@@ -152,9 +159,15 @@ void NodesFree(Nodes *nodes) {
   }
 }
 
-int NodesSize(const Nodes *nodes) { return nodes->len; }
+int NodesSize(const Nodes *nodes) {
+  assert(nodes);
+
+  return nodes->len;
+}
 
 void *NodeAt(const Nodes *nodes, int index) {
+  assert(nodes);
+
   if (index < nodes->len) {
     return nodes->results[index];
   }
@@ -190,6 +203,8 @@ void UastFree(Uast *ctx) {
 }
 
 UastIterator *UastIteratorNew(const Uast *ctx, void *node, TreeOrder order) {
+  assert(ctx);
+  assert(node);
 
   UastIterator *iter = UastIteratorNewBase(ctx, node, order);
   iter->pending.push_front(node);
@@ -207,6 +222,10 @@ void UastIteratorFree(UastIterator *iter) {
 UastIterator *UastIteratorNewWithTransformer(const Uast *ctx, void *node,
                                              TreeOrder order, TransformFunc transform) {
 
+  assert(ctx);
+  assert(node);
+  assert(transform);
+
   UastIterator *iter = UastIteratorNewBase(ctx, node, order);
   iter->pending.push_front(transform(node));
   iter->nodeTransform = transform;
@@ -214,6 +233,7 @@ UastIterator *UastIteratorNewWithTransformer(const Uast *ctx, void *node,
 }
 
 void *UastIteratorNext(UastIterator *iter) {
+  assert(iter);
 
   if (iter == nullptr || iter->pending.empty()) {
     if (iter == nullptr) {
@@ -232,9 +252,15 @@ void *UastIteratorNext(UastIterator *iter) {
   }
 }
 
-NodeIface UastGetIface(const Uast *ctx) { return ctx->iface; }
+NodeIface UastGetIface(const Uast *ctx) {
+  assert(ctx);
+  return ctx->iface;
+}
 
 Nodes *UastFilter(const Uast *ctx, void *node, const char *query) {
+  assert(ctx);
+  assert(node);
+  assert(query);
 
   Nodes *nodes;
   try {
@@ -293,6 +319,10 @@ Nodes *UastFilter(const Uast *ctx, void *node, const char *query) {
 
 bool UastFilterBool(const Uast *ctx, void *node, const char *query,
                     bool *ok) {
+  assert(ctx);
+  assert(node);
+  assert(query);
+
   try {
     QueryResult queryResult(ctx, node, query, XPATH_BOOLEAN);
     *ok = true;
@@ -305,6 +335,10 @@ bool UastFilterBool(const Uast *ctx, void *node, const char *query,
 
 double UastFilterNumber(const Uast *ctx, void *node, const char *query,
                         bool *ok) {
+  assert(ctx);
+  assert(node);
+  assert(query);
+
   try {
     QueryResult queryResult(ctx, node, query, XPATH_NUMBER);
     *ok = true;
@@ -316,6 +350,10 @@ double UastFilterNumber(const Uast *ctx, void *node, const char *query,
 }
 
 const char *UastFilterString(const Uast *ctx, void *node, const char *query) {
+  assert(ctx);
+  assert(node);
+  assert(query);
+
   try {
     QueryResult queryResult(ctx, node, query, XPATH_STRING);
     char *cstr = reinterpret_cast<char *>(queryResult.xpathObj->stringval);
@@ -340,6 +378,8 @@ char *LastError(void) {
 Nodes *NodesNew() { return new Nodes(); }
 
 int NodesSetSize(Nodes *nodes, int len) {
+  assert(nodes);
+
   if (len > nodes->cap) {
     nodes->results.resize(len);
     nodes->cap = len;
@@ -348,10 +388,17 @@ int NodesSetSize(Nodes *nodes, int len) {
   return 0;
 }
 
-int NodesCap(const Nodes *nodes) { return nodes->cap; }
+int NodesCap(const Nodes *nodes) {
+  assert(nodes);
+
+  return nodes->cap;
+}
 
 static xmlNodePtr CreateXmlNode(const Uast *ctx, void *node,
                                 xmlNodePtr parent) {
+  assert(ctx);
+  assert(node);
+
   char buf[BUF_SIZE];
 
   const char *internal_type = ctx->iface.InternalType(node);
@@ -475,6 +522,9 @@ static xmlNodePtr CreateXmlNode(const Uast *ctx, void *node,
 }
 
 static xmlDocPtr CreateDocument(const Uast *ctx, void *node) {
+  assert(ctx);
+  assert(node);
+
   auto doc = static_cast<xmlDocPtr>(xmlNewDoc(BAD_CAST("1.0")));
   if (!doc) {
     return nullptr;
@@ -489,19 +539,27 @@ static xmlDocPtr CreateDocument(const Uast *ctx, void *node) {
 }
 
 void Error(void *ctx, const char *msg, ...) {
-   va_list arg_ptr;
+  assert(ctx);
 
-   va_start(arg_ptr, msg);
-   vsnprintf(error_message, BUF_SIZE, msg, arg_ptr);
-   va_end(arg_ptr);
+  va_list arg_ptr;
+
+  va_start(arg_ptr, msg);
+  vsnprintf(error_message, BUF_SIZE, msg, arg_ptr);
+  va_end(arg_ptr);
 }
 
 static void *transformChildAt(UastIterator *iter, void *parent, size_t pos) {
+  assert(iter);
+  assert(parent);
+
   auto child = iter->ctx->iface.ChildAt(parent, pos);
   return iter->nodeTransform ? iter->nodeTransform(child): child;
 }
 
 static bool Visited(UastIterator *iter, void *node) {
+  assert(iter);
+  assert(node);
+
   const bool visited = iter->visited.find(node) != iter->visited.end();
 
   if(!visited) {
@@ -516,6 +574,8 @@ static bool Visited(UastIterator *iter, void *node) {
 }
 
 static void *PreOrderNext(UastIterator *iter) {
+  assert(iter);
+
   void *retNode = iter->pending.front();
   iter->pending.pop_front();
 
@@ -532,6 +592,8 @@ static void *PreOrderNext(UastIterator *iter) {
 }
 
 static void *LevelOrderNext(UastIterator *iter) {
+  assert(iter);
+
   void *retNode = iter->pending.front();
 
   if (retNode == nullptr) {
@@ -548,6 +610,8 @@ static void *LevelOrderNext(UastIterator *iter) {
 }
 
 static void *PostOrderNext(UastIterator *iter) {
+  assert(iter);
+
   void *curNode = iter->pending.front();
   if (curNode == nullptr) {
     return nullptr;

--- a/src/uast.cc
+++ b/src/uast.cc
@@ -29,7 +29,7 @@ struct UastIterator {
   TreeOrder order;
   std::deque<void *> pending;
   std::set<void *> visited;
-  void* (*nodeTransform)(void*);
+  TransformFunc nodeTransform;
 };
 
 struct Nodes {
@@ -205,7 +205,7 @@ void UastIteratorFree(UastIterator *iter) {
 }
 
 UastIterator *UastIteratorNewWithTransformer(const Uast *ctx, void *node,
-                                             TreeOrder order, void*(*transform)(void*)) {
+                                             TreeOrder order, TransformFunc transform) {
 
   UastIterator *iter = UastIteratorNewBase(ctx, node, order);
   iter->pending.push_front(transform(node));

--- a/src/uast.cc
+++ b/src/uast.cc
@@ -236,9 +236,6 @@ void *UastIteratorNext(UastIterator *iter) {
   assert(iter);
 
   if (iter == nullptr || iter->pending.empty()) {
-    if (iter == nullptr) {
-    } else if (iter->pending.empty()) {
-    }
     return nullptr;
   }
 

--- a/src/uast.cc
+++ b/src/uast.cc
@@ -30,7 +30,7 @@ struct UastIterator {
   TreeOrder order;
   std::deque<void *> pending;
   std::set<void *> visited;
-  TransformFunc nodeTransform;
+  void* (*nodeTransform)(void*);
 };
 
 struct Nodes {
@@ -220,7 +220,7 @@ void UastIteratorFree(UastIterator *iter) {
 }
 
 UastIterator *UastIteratorNewWithTransformer(const Uast *ctx, void *node,
-                                             TreeOrder order, TransformFunc transform) {
+                                             TreeOrder order, void*(*transform)(void*)) {
 
   assert(ctx);
   assert(node);

--- a/src/uast.h
+++ b/src/uast.h
@@ -8,8 +8,6 @@ extern "C" {
 #include "node_iface.h"
 #include "nodes.h"
 
-#include <jni.h> // XXX
-
 // Uast stores the general context required for library functions.
 // It must be initialized with `UastNew` passing a valid implementation of the
 // `NodeIface` interface.

--- a/src/uast.h
+++ b/src/uast.h
@@ -21,6 +21,11 @@ typedef struct UastIterator UastIterator;
 
 typedef enum { PRE_ORDER, POST_ORDER, LEVEL_ORDER } TreeOrder;
 
+// void*(void*) function used as argument to UastIteratorNewWithTransform to transform
+// the nodes (increase references for the local bindings, typically) before
+// being added to the internal iterator data structures.
+typedef void*(*TransformFunc)(void*);
+
 // Uast needs a node implementation in order to work. This is needed
 // because the data structure of the node itself is not defined by this
 // library, instead it provides an interface that is expected to be satisfied by

--- a/src/uast.h
+++ b/src/uast.h
@@ -8,6 +8,8 @@ extern "C" {
 #include "node_iface.h"
 #include "nodes.h"
 
+#include <jni.h> // XXX
+
 // Uast stores the general context required for library functions.
 // It must be initialized with `UastNew` passing a valid implementation of the
 // `NodeIface` interface.
@@ -84,6 +86,13 @@ const char *UastFilterString(const Uast *ctx, void *node, const char *query);
 // Returns NULL and sets LastError if the UastIterator couldn't initialize.
 UastIterator *UastIteratorNew(const Uast *ctx, void *node, TreeOrder order);
 
+// Same as UastIteratorNew, but also allows to specify a transform function taking a node
+// and returning it. This is specially useful when the bindings need to do operations like
+// increasing / decreasing the language reference count when new nodes are added to the
+// iterator internal data structures.
+UastIterator *UastIteratorNewWithTransformer(const Uast *ctx, void *node,
+                                             TreeOrder order, void*(*transform)(void*));
+
 // Frees a UastIterator.
 void UastIteratorFree(UastIterator *iter);
 
@@ -100,5 +109,4 @@ char *LastError(void);
 #ifdef __cplusplus
 }  // extern "C"
 #endif
-
 #endif  // LIBUAST_UAST_H_

--- a/src/uast.h
+++ b/src/uast.h
@@ -21,11 +21,6 @@ typedef struct UastIterator UastIterator;
 
 typedef enum { PRE_ORDER, POST_ORDER, LEVEL_ORDER } TreeOrder;
 
-// void*(void*) function used as argument to UastIteratorNewWithTransform to transform
-// the nodes (increase references for the local bindings, typically) before
-// being added to the internal iterator data structures.
-typedef void*(*TransformFunc)(void*);
-
 // Uast needs a node implementation in order to work. This is needed
 // because the data structure of the node itself is not defined by this
 // library, instead it provides an interface that is expected to be satisfied by

--- a/tests/main.cc
+++ b/tests/main.cc
@@ -29,6 +29,7 @@ int main() {
   ADD_TEST(suite, "test of RoleNameForId()", TestRoleNameForId);
   ADD_TEST(suite, "test of UastNew()", TestUastNew);
   ADD_TEST(suite, "test of UastFilter() pointers", TestUastFilterPointers);
+  ADD_TEST(suite, "test iterator transform func", TestUastIteratorTransformFunc);
   ADD_TEST(suite, "test iteration", TestUastIteratorPreOrder);
   ADD_TEST(suite, "test iteration", TestUastIteratorLevelOrder);
   ADD_TEST(suite, "test iteration", TestUastIteratorPostOrder);

--- a/tests/nodes_test.h
+++ b/tests/nodes_test.h
@@ -545,6 +545,44 @@ void TestUastFilterXPathFuncContains() {
   UastFree(ctx);
 }
 
+static int calls = 0;
+
+void* transformTest(void *node) {
+  ++calls;
+  return node;
+}
+
+void TestUastIteratorTransformFunc() {
+  Uast *ctx = UastNew(IfaceMock());
+  Node *root = TreeMock();
+
+  UastIterator *iter = UastIteratorNewWithTransformer(ctx, root, PRE_ORDER, transformTest);
+  CU_ASSERT_FATAL(iter != NULL);
+  CU_ASSERT_FATAL(calls == 1);
+  UastIteratorNext(iter);
+  CU_ASSERT_FATAL(calls == 4);
+  UastIteratorFree(iter);
+
+  calls = 0;
+  iter = UastIteratorNewWithTransformer(ctx, root, POST_ORDER, transformTest);
+  CU_ASSERT_FATAL(iter != NULL);
+  CU_ASSERT_FATAL(calls == 1);
+  UastIteratorNext(iter);
+  CU_ASSERT_FATAL(calls == 6);
+  UastIteratorFree(iter);
+
+  calls = 0;
+  iter = UastIteratorNewWithTransformer(ctx, root, LEVEL_ORDER, transformTest);
+  CU_ASSERT_FATAL(iter != NULL);
+  CU_ASSERT_FATAL(calls == 1);
+  UastIteratorNext(iter);
+  CU_ASSERT_FATAL(calls == 4);
+  UastIteratorFree(iter);
+
+  UastFree(ctx);
+}
+
+
 void TestUastIteratorPreOrder() {
   Uast *ctx = UastNew(IfaceMock());
   Node *root = TreeMock();


### PR DESCRIPTION
[Note: this is needed for the next version of the Scala client].

- It'll allow to specify callbacks that will be called before adding
  a node to the internal iterator data structures. This will allow for
  bindings that need to increase/decrease refs or manage memory in a special
  way (like JNI for example) to do so, in the callback.

- Include cleanup.

Signed-off-by: Juanjo Alvarez <juanjo@sourced.tech>