### PR TITLE
fix memory leak: remove duplicate Nodes allocation

### DIFF
--- a/src/uast.cc
+++ b/src/uast.cc
@@ -278,13 +278,6 @@ Nodes *UastFilter(const Uast *ctx, void *node, const char *query) {
         throw std::runtime_error("");
     }
 
-    try {
-      nodes = new Nodes();
-    } catch(const std::bad_alloc&) {
-      Error(nullptr, "Unable to get memory for nodes\n");
-      throw std::runtime_error("");
-    }
-
     auto results = nodeset->nodeTab;
     auto size = nodeset->nodeNr;
     size_t realSize = 0;


### PR DESCRIPTION
In the `UastFilter` function of `uast.cc`, a new `Nodes` object was allocated twice, without freeing the first allocation. This PR simply removes the second allocation and adds a `runtime_error` to the first on failure.

The memory leak can be demonstrated via a simple example:
```c
while (true) {
  Nodes *nodes = UastFilter(ctx, &root, "/compilation_unit//identifier");
  NodesFree(nodes);
}
```