### PR TITLE
Check CMAKE_CXX_COMPILER_ID instead of CMAKE_COMPILER_IS_GNUCXX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ if(NOT ("${CMAKE_BUILD_TYPE}" STREQUAL "Debug") AND NOT ("${CMAKE_BUILD_TYPE}" S
     set(CMAKE_BUILD_TYPE "Release")
 endif()
 
-if(${CMAKE_COMPILER_IS_GNUCXX} AND (${CMAKE_BUILD_TYPE} STREQUAL "Debug"))
+if(${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU" AND (${CMAKE_BUILD_TYPE} STREQUAL "Debug"))
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O0 -fprofile-arcs -ftest-coverage")
     include(CodeCoverage)
     setup_target_for_coverage(${PROJECT_NAME}_coverage tests coverage)


### PR DESCRIPTION
Signed-off-by: kuba-- <kuba@sourced.tech>

It's known that `CMAKE_COMPILER_IS_GNUCXX` is an empty string on some platforms. For instance on _OSX High Sierra_  I couldn't build it because this var was an empty string. I replaced it by:
`${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU"`