### PR TITLE
fix Windows binaries for cross-compilation

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,10 +4,6 @@ image:
   - Visual Studio 2015
   - Visual Studio 2017
 
-matrix:
-  allow_failures:
-    - platform: x64
-
 clone_folder: c:\libuast
 
 environment:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,8 @@
 version: "{build}"
 platform: x64
-image: Visual Studio 2017
+image:
+  - Visual Studio 2015
+  - Visual Studio 2017
 
 matrix:
   allow_failures:
@@ -15,26 +17,34 @@ environment:
     - BUILD: mingw
     - BUILD: msvc
 
+matrix:
+  exclude:
+    - image: Visual Studio 2017
+      BUILD: mingw
+    - image: Visual Studio 2015
+      BUILD: msvc
+
 install:
   - git clone --depth 1 https://github.com/GNOME/libxml2 c:\libxml2
-  - if %BUILD% == mingw c:\msys64\usr\bin\pacman --noconfirm --needed -S mingw-w64-x86_64-toolchain
-  - if %BUILD% == mingw choco install make
+  # Use preinstalled mingw 6.3.0, note that using 7.3.0 causes problems with
+  # the compiled libraries when linking against them, at least when cross-compiling
+  # from older GCC. Test these scenarios if you consider upgrading mingw here.
+  - if %BUILD% == mingw set PATH=C:\mingw-w64\x86_64-6.3.0-posix-seh-rt_v5-rev1\mingw64\bin;%PATH%
   - if %BUILD% == msvc call "%VS150COMNTOOLS%\..\..\VC\Auxiliary\Build\vcvarsall.bat" amd64
 
 build_script:
-  - if %BUILD% == mingw set PATH=C:\msys64\mingw64\bin;%PATH%
   # Workaround for CMake+MinGW conflicting with sh.exe in PATH
   - if %BUILD% == mingw set PATH=%PATH:C:\Program Files\Git\usr\bin;=%
   - cd c:\libxml2\win32
   - cscript configure.js ftp=no http=no c14n=no docb=no iconv=no legacy=no prefix=%PREFIX% compiler=%BUILD%
-  - if %BUILD% == mingw make -f Makefile.mingw install
+  - if %BUILD% == mingw mingw32-make -f Makefile.mingw install
   - if %BUILD% == msvc nmake /f Makefile.msvc install
   - cd c:\libuast
   - mkdir build
   - cd build
   - if %BUILD% == mingw cmake -G "MinGW Makefiles" -DCMAKE_INSTALL_PREFIX=%PREFIX% -DLIBXML2_LIBRARY=%PREFIX%\lib\libxml2.a -DLIBXML2_INCLUDE_DIR=%PREFIX%\include\libxml2 -DDISABLE_EXAMPLES=1 ..
   - if %BUILD% == msvc cmake -DCMAKE_GENERATOR_PLATFORM=x64 -DCMAKE_INSTALL_PREFIX=%PREFIX% -DLIBXML2_LIBRARY=%PREFIX%\lib\libxml2.lib -DLIBXML2_INCLUDE_DIR=%PREFIX%\include\libxml2 -DDISABLE_EXAMPLES=1 ..
-  - if %BUILD% == mingw make install
+  - if %BUILD% == mingw mingw32-make install
   - if %BUILD% == msvc cmake --build . --target install --config Release
   - 7z a c:\libuast\binaries.win64.%BUILD%.zip %PREFIX%\*
 


### PR DESCRIPTION
Cross-compiling for Windows from Linux fails, at least on Ubuntu 16.04
with GCC 4.8 (e.g. with xgo). The error is the following:

```
../../vendor/gopkg.in/bblfsh/client-go.v2/tools/lib/libxml2.a(error.o):error.c:(.text+0x242): undefined reference to `__imp___acrt_iob_func'
../../vendor/gopkg.in/bblfsh/client-go.v2/tools/lib/libxml2.a(parserInternals.o):parserInternals.c:(.text+0x5d1): undefined reference to `__imp___acrt_iob_func'
../../vendor/gopkg.in/bblfsh/client-go.v2/tools/lib/libxml2.a(relaxng.o):relaxng.c:(.text+0x1de7): undefined reference to `__imp___acrt_iob_func'
../../vendor/gopkg.in/bblfsh/client-go.v2/tools/lib/libxml2.a(relaxng.o):relaxng.c:(.text+0xb407): undefined reference to `__imp___acrt_iob_func'
../../vendor/gopkg.in/bblfsh/client-go.v2/tools/lib/libxml2.a(relaxng.o):relaxng.c:(.text+0xb44e): undefined reference to `__imp___acrt_iob_func'
../../vendor/gopkg.in/bblfsh/client-go.v2/tools/lib/libxml2.a(relaxng.o):relaxng.c:(.text+0xb4a7): more undefined references to `__imp___acrt_iob_func' follow
collect2: error: ld returned 1 exit status
```

This seems to be a problem with libxml2 compiled with mingw's gcc 7.3. Compiling it with gcc 6.3 solves the problem.

Turns out that AppVeyor have both versions pre-installed in the Visual Studio 2015 image. So, for mingw builds, we switch to Visual Studio 2015 image plus mingw 6.3.0. msvc builds still use Visual Studio 2017 image.

Signed-off-by: Santiago M. Mola <santi@mola.io>