### PR TITLE
Return an empty list instead of an error when a property is not matched

### DIFF
--- a/src/uast.cc
+++ b/src/uast.cc
@@ -281,8 +281,12 @@ Nodes *UastFilter(const Uast *ctx, void *node, const char *query) {
 
     auto nodeset = queryResult.xpathObj->nodesetval;
     if (!nodeset) {
-        Error(nullptr, "Unable to get array of result nodes\n");
+      if (NodesSetSize(nodes, 0) != 0) {
+        Error(nullptr, "Unable to set nodes size\n");
         throw std::runtime_error("");
+      }
+
+      return nodes;
     }
 
     auto results = nodeset->nodeTab;

--- a/tests/nodes_test.h
+++ b/tests/nodes_test.h
@@ -929,10 +929,9 @@ void TestEmptyResult() {
   NodeIface iface = IfaceMock();
   Uast *ctx = UastNew(iface);
   Node module = Node("Module");
-
-  CU_ASSERT_FATAL(UastFilter(ctx, &module,
-                             "//Import[@roleImport]//alias") == NULL);
-  UastFree(ctx);
+  auto nodes = UastFilter(ctx, &module, "//Import[@roleImport]//alias");
+  CU_ASSERT_FATAL(nodes != NULL);
+  CU_ASSERT_FATAL(NodesSize(nodes) == 0);
 }
 
 void TestXmlNewDoc() {


### PR DESCRIPTION
Emergency fix for @eiso's demos.

Currently, trying to match a missing property from an existing node returns an error. This would make it return an empty result list instead.

Note that this is based on v1.9.4 because v2.0.0 would require updating the client-python which is not worth since libuast will be replaced now. So this version will merge into the `1.9-branch` and would become v1.9.5 and the python and go clients would link to it on new PRs until we've a new libuast-go and all the clients are updated. Then I'll do a separate PR for the `~master` branch.

Signed-off-by: Juanjo Alvarez juanjo@sourced.tech