### PR TITLE
Return an empty list instead of an error when a property is not matched

### DIFF
--- a/src/uast.cc
+++ b/src/uast.cc
@@ -281,8 +281,11 @@ Nodes *UastFilter(const Uast *ctx, NodeHandle node, const char *query) {
 
     auto nodeset = queryResult.xpathObj->nodesetval;
     if (!nodeset) {
-        Error(nullptr, "Unable to get array of result nodes\n");
-        throw std::runtime_error("");
+      if (NodesSetSize(nodes, 0) != 0) {
+        Error(nullptr, "Unable to set nodes size\n");
+        throw std::runtime_error("");	        throw std::runtime_error("");
+      }
+      return nodes;
     }
 
     auto results = nodeset->nodeTab;

--- a/tests/nodes_test.h
+++ b/tests/nodes_test.h
@@ -929,9 +929,11 @@ void TestEmptyResult() {
   NodeIface iface = IfaceMock();
   Uast *ctx = UastNew(iface);
   Node module = Node("Module");
+  auto nodes = UastFilter(ctx, NodeHandle(&module), "//Import[@roleImport]//alias");
+  CU_ASSERT_FATAL(nodes != NULL);
+  CU_ASSERT_FATAL(NodesSize(nodes) == 0);
 
-  CU_ASSERT_FATAL(UastFilter(ctx, NodeHandle(&module),
-                             "//Import[@roleImport]//alias") == NULL);
+  NodesFree(nodes);
   UastFree(ctx);
 }
 


### PR DESCRIPTION
Same as bblfsh/libuast/pull/86 for the `~master` branch.

Signed-off-by: Juanjo Alvarez <juanjo@sourced.tech>