### PR TITLE
Windows static lib support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,7 @@ ifneq ("$(HOSTOS)", "windows")
 build-windows: $(DEPS_C) $(DEPS_GO)
 	mkdir -p $(OUT_WINDOWS)
 	GOOS=windows GOARCH=amd64 CGO_ENABLED=1 CC=$(CC_WIN64) $(GO_BUILD) $(BUILD_MODE) -o=$(OUT_WINDOWS)/$(OUT_NAME).dll $(SRC_DIR)/
+	GOOS=windows GOARCH=amd64 CGO_ENABLED=1 CC=$(CC_WIN64) $(GO_BUILD) $(BUILD_MODE_STATIC) -o=$(OUT_WINDOWS)/$(OUT_NAME).lib $(SRC_DIR)/
 	$(GEN_HEADER) $(OUT_WINDOWS)/$(OUT_HEADER)
 	$(CP_HEADERS) $(OUT_WINDOWS)/
 

--- a/src/libuast.hpp
+++ b/src/libuast.hpp
@@ -7,6 +7,17 @@
 #include <iostream>
 #include <cstring>
 
+// Workaround for linking libs cross-compiled with gcc vs VS2015 libs
+// See: https://stackoverflow.com/questions/30412951/unresolved-external-symbol-imp-fprintf-and-imp-iob-func-sdl2
+#ifdef _WIN32
+    FILE _iob[] = {*stdin, *stdout, *stderr};
+
+    extern "C" FILE * __cdecl __iob_func(void)
+    {
+        return _iob;
+    }
+#endif
+
 namespace uast {
     struct Buffer {
         Buffer(void*  p, size_t sz) : ptr(p), size(sz) {}

--- a/src/libuast.hpp
+++ b/src/libuast.hpp
@@ -14,7 +14,7 @@
 
     extern "C" FILE * __cdecl __iob_func(void)
     {
-        return _iob;
+        return &(_iob[0]);
     }
 #endif
 


### PR DESCRIPTION
- Generate the static lib.

- Workaround for allowing linking an object cross-compiled with gcc versus
  Visual Studio.

Signed-off-by: Juanjo Alvarez <juanjo@sourced.tech>