### PR TITLE
Expose memory statistics

### DIFF
--- a/src/api.go
+++ b/src/api.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"runtime"
 	"unsafe"
 
 	"gopkg.in/bblfsh/sdk.v2/uast"
@@ -356,4 +357,15 @@ func RoleIdForName(name *C.char) C.int {
 	s := C.GoString(name)
 	r := role.FromString(s)
 	return C.int(r)
+}
+
+//export UastReadMemStats
+// UastReadMemStats fills in current memory statistics. This call may affect libuast performance.
+func UastReadMemStats(st *C.UastMemStats) {
+	var m runtime.MemStats
+	// this may cause stop-the-world, hence the comment about performance
+	runtime.ReadMemStats(&m)
+
+	st.allocated = C.uint64_t(m.Alloc)
+	st.objects = C.uint64_t(m.Mallocs - m.Frees)
 }

--- a/src/libuast.hpp
+++ b/src/libuast.hpp
@@ -27,6 +27,13 @@ namespace uast {
         size_t size;
     };
 
+    // MemStats returns current memory usage for libuast.
+    UastMemStats MemStats() {
+        UastMemStats st;
+        UastReadMemStats(&st);
+        return st;
+    }
+
     // Role of UAST node.
     class Role {
     private:

--- a/src/uast.h
+++ b/src/uast.h
@@ -143,6 +143,12 @@ static NodeHandle UastLoad(const Uast *src, NodeHandle n, const Uast *dst) {
       return 0;
 }
 
+// UastMemStats holds memory statistics for libuast.
+typedef struct UastMemStats {
+ uint64_t allocated; // bytes allocated for live objects
+ uint64_t objects;   // number of live objects
+} UastMemStats;
+
 /*GO-HEADER*/
 
 #endif // UAST_H_


### PR DESCRIPTION
Expose memory usage of `libuast`. This should help to track memory leaks that happen across the library boundary.

Signed-off-by: Denys Smirnov <denys@sourced.tech>