### PR TITLE
Only use the workaround with MSVC >= 15.0

### DIFF
--- a/src/libuast.hpp
+++ b/src/libuast.hpp
@@ -9,13 +9,15 @@
 
 // Workaround for linking libs cross-compiled with gcc vs VS2015 libs
 // See: https://stackoverflow.com/questions/30412951/unresolved-external-symbol-imp-fprintf-and-imp-iob-func-sdl2
-#ifdef _WIN32
-    FILE _iob[] = {*stdin, *stdout, *stderr};
+#ifdef _MSC_VER
+    #if _MSC_VER >= 1900
+        FILE _iob[] = {*stdin, *stdout, *stderr};
 
-    extern "C" FILE * __cdecl __iob_func(void)
-    {
-        return &(_iob[0]);
-    }
+        extern "C" FILE * __cdecl __iob_func(void)
+        {
+            return &(_iob[0]);
+        }
+    #endif
 #endif
 
 namespace uast {


### PR DESCRIPTION
Fixes https://github.com/bblfsh/libuast/issues/68

Tentative PR to see if this fixes the problem with appveyor compiler.

Edit: works!

Signed-off-by: Juanjo Alvarez <juanjo@sourced.tech>