### PR TITLE
Fixes possible memory leaks

### DIFF
--- a/src/libuast.hpp
+++ b/src/libuast.hpp
@@ -3,7 +3,7 @@
 // C++ helpers to make it easier to implement NodeIface and work with Uast context.
 
 #include "libuast.h"
-#include <map>
+#include <unordered_map>
 #include <iostream>
 #include <cstring>
 
@@ -271,12 +271,12 @@ namespace uast {
             return n;
         }
 
-        static std::map<UastHandle,RawContext*>& contexts() {
-            static std::map<UastHandle,RawContext*> v; return v;
+        static std::unordered_map<UastHandle,RawContext*>& contexts() {
+            static std::unordered_map<UastHandle,RawContext*> v; return v;
         }
 
-        static std::map<UastHandle,RawContext*>& nativeContexts() {
-            static std::map<UastHandle,RawContext*> v; return v;
+        static std::unordered_map<UastHandle,RawContext*>& nativeContexts() {
+            static std::unordered_map<UastHandle,RawContext*> v; return v;
         }
 
         static RawContext* getContext(const Uast* ctx) {
@@ -306,14 +306,15 @@ namespace uast {
         ~RawContext() {
             UastHandle nativeHandle = ctx->ctx;
             UastFree(ctx);
-
+            ctx = nullptr;
             if (handle == 0) {
                 nativeContexts().erase(nativeHandle);
             } else {
                 contexts().erase(handle);
             }
-
+            handle = 0;
             delete(impl);
+            impl = nullptr;
         }
 
         Uast* rawPointer() { return ctx; }

--- a/src/libuast.hpp
+++ b/src/libuast.hpp
@@ -289,6 +289,7 @@ namespace uast {
         RawContext(NodeRawInterface* iface, Uast* c = nullptr) {
             impl = iface;
             if (c != nullptr) {
+                handle = 0;
                 // allocated natively, check the handle and use it (in a separate map)
                 if (c->ctx  == 0) throw std::runtime_error("zero handle on a native context");
                 nativeContexts()[c->ctx] = this;
@@ -311,7 +312,7 @@ namespace uast {
             } else {
                 contexts().erase(handle);
             }
-            handle = 0;
+
             delete(impl);
         }
 

--- a/src/libuast.hpp
+++ b/src/libuast.hpp
@@ -313,7 +313,6 @@ namespace uast {
                 contexts().erase(handle);
             }
             handle = 0;
-            delete(impl);
             impl = nullptr;
         }
 

--- a/src/libuast.hpp
+++ b/src/libuast.hpp
@@ -305,14 +305,14 @@ namespace uast {
         ~RawContext() {
             UastHandle nativeHandle = ctx->ctx;
             UastFree(ctx);
-            ctx = nullptr;
+
             if (handle == 0) {
                 nativeContexts().erase(nativeHandle);
             } else {
                 contexts().erase(handle);
             }
             handle = 0;
-            impl = nullptr;
+            delete(impl);
         }
 
         Uast* rawPointer() { return ctx; }

--- a/src/uast.h
+++ b/src/uast.h
@@ -119,43 +119,51 @@ static NodeHandle UastLoad(const Uast *src, NodeHandle n, const Uast *dst) {
     if (kind == NODE_NULL) {
         return 0;
     } else if (kind == NODE_OBJECT) {
-        size_t sz = UAST_CALL(src, Size, n);
+      size_t sz = UAST_CALL(src, Size, n);
 
-        NodeHandle m = UAST_CALL(dst, NewObject, sz);
-        size_t i;
-        for (i = 0; i < sz; i++) {
-            const char * k = UAST_CALL(src, KeyAt, n, i);
-            if (!k) {
-                return 0;
-            }
-            NodeHandle v = UAST_CALL(src, ValueAt, n, i);
-            v = UastLoad(src, v, dst);
-            UAST_CALL(dst, SetKeyValue, m, k, v);
-        }
-        return m;
-      } else if (kind == NODE_ARRAY) {
-        size_t sz = UAST_CALL(src, Size, n);
+      NodeHandle m = UAST_CALL(dst, NewObject, sz);
+      size_t i;
 
-        NodeHandle m = UAST_CALL(dst, NewArray, sz);
-        size_t i;
-        for (i = 0; i < sz; i++) {
-            NodeHandle v = UAST_CALL(src, ValueAt, n, i);
-            v = UastLoad(src, v, dst);
-            UAST_CALL(dst, SetValue, m, i, v);
+      for (i = 0; i < sz; i++) {
+        char* k = UAST_CALL(src, KeyAt, n, i);
+
+        if (!k) {
+          return 0;
         }
-        return m;
-      } else if (kind == NODE_STRING) {
-        return UAST_CALL(dst, NewString, UAST_CALL(src, AsString, n));
-      } else if (kind == NODE_INT) {
-        return UAST_CALL(dst, NewInt, UAST_CALL(src, AsInt, n));
-      } else if (kind == NODE_UINT) {
-        return UAST_CALL(dst, NewUint, UAST_CALL(src, AsUint, n));
-      } else if (kind == NODE_FLOAT) {
-        return UAST_CALL(dst, NewFloat, UAST_CALL(src, AsFloat, n));
-      } else if (kind == NODE_BOOL) {
-        return UAST_CALL(dst, NewBool, UAST_CALL(src, AsBool, n));
+
+        NodeHandle v = UAST_CALL(src, ValueAt, n, i);
+        v = UastLoad(src, v, dst);
+        UAST_CALL(dst, SetKeyValue, m, k, v);
+        free(k);
       }
-      return 0;
+      return m;
+    } else if (kind == NODE_ARRAY) {
+      size_t sz = UAST_CALL(src, Size, n);
+
+      NodeHandle m = UAST_CALL(dst, NewArray, sz);
+      size_t i;
+      for (i = 0; i < sz; i++) {
+        NodeHandle v = UAST_CALL(src, ValueAt, n, i);
+        v = UastLoad(src, v, dst);
+        UAST_CALL(dst, SetValue, m, i, v);
+      }
+      return m;
+    } else if (kind == NODE_STRING) {
+      char *s = UAST_CALL(src, AsString, n);
+      NodeHandle m = UAST_CALL(dst, NewString, s);
+      free(s);
+      return m;
+    } else if (kind == NODE_INT) {
+      return UAST_CALL(dst, NewInt, UAST_CALL(src, AsInt, n));
+    } else if (kind == NODE_UINT) {
+      return UAST_CALL(dst, NewUint, UAST_CALL(src, AsUint, n));
+    } else if (kind == NODE_FLOAT) {
+      return UAST_CALL(dst, NewFloat, UAST_CALL(src, AsFloat, n));
+    } else if (kind == NODE_BOOL) {
+      return UAST_CALL(dst, NewBool, UAST_CALL(src, AsBool, n));
+    }
+
+    return 0;
 }
 
 // UastMemStats holds memory statistics for libuast.


### PR DESCRIPTION
Fixed memory leaks / problems:

* In the [destructor of `RawContext`](https://github.com/ncordon/libuast/blob/cb50793c12d55ab66a8e40c5f09da09d524f3dea/src/libuast.hpp#L305) `impl` was not being deleted, and it should, since [here](https://github.com/ncordon/libuast/blob/cb50793c12d55ab66a8e40c5f09da09d524f3dea/src/libuast.hpp#L607) we would have an unreachable interface. Note this may be one of the roots that simply doing `parse` from the [python-client](https://github.com/bblfsh/python-client/issues/167) may end up in memory leaks, since the stack of calls is as follows (copied-pasted from `valgrind` - note lines may change - because of the version of `libuast` that the `python-client` is using):

```
==23425==    at 0x4838DEF: operator new(unsigned long) (vg_replace_malloc.c:334)
==23425==    by 0x8DBCB61: uast::Decode(uast::Buffer, UastFormat) (libuast.hpp:607)
==23425==    by 0x8DBD586: PythonContextExt_decode(_object*, _object*, _object*) (pyuast.cc:1040)
```

* Adds missing [`handle` initialization](https://github.com/ncordon/libuast/blob/cb50793c12d55ab66a8e40c5f09da09d524f3dea/src/libuast.hpp#L289) in the `RawContext` constructor. I think an integer is always initialized to 0 in g++ and newer standards of C++ but it is not always guaranteed. I am not sure anyway. The only information I have found regarding this is [here](http://mikelui.io/2019/01/03/seriously-bonkers.html). `valgrind` was complaining with:

```
==23425== Conditional jump or move depends on uninitialised value(s)
==23425==    at 0x8DBD0DC: ~RawContext (libuast.hpp:309)
==23425==    by 0x8DBD0DC: ~RawContext (libuast.hpp:316)
==23425==    by 0x8DBD0DC: ~ContextExt (pyuast.cc:243)
==23425==    by 0x8DBD0DC: PythonContextExt_dealloc(_object*) (pyuast.cc:318)
```

* We were not freeing strings created by [`KeyAt`](https://github.com/bblfsh/libuast/blob/cb50793c12d55ab66a8e40c5f09da09d524f3dea/src/uast.h#L127) and [`AsString`](https://github.com/bblfsh/libuast/blob/cb50793c12d55ab66a8e40c5f09da09d524f3dea/src/uast.h#L148). This was the main source of the memory leaks.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bblfsh/libuast/107)
<!-- Reviewable:end -->
